### PR TITLE
Fix tier header images

### DIFF
--- a/src/data/tierImages.js
+++ b/src/data/tierImages.js
@@ -1,17 +1,17 @@
 // Map tier names to their corresponding image paths
 export const tierImages = {
-  'The Pantheon': '/pantheon-tier.png',
-  'Cheers Survivor': '/cheers-tier.png',
-  'Next Level Survivor': '/next-level-tier.png',
-  'Hitting on All Cylinders': '/all-cylinders-tier.png',
-  'The Good, the Bad, and the Ugly': '/good-bad-ugly-tier.png',
-  'Impossible to Rank': '/impossible-rank-tier.png',
-  'Replacement Level Survivor': '/replacement-tier.png',
-  'The New Era Malaise': '/new-era-malaise.png',
-  'The Shit Show Seasons': '/shit-show-tier.png',
-  'The Bleh': '/bleh-tier.png',
-  'Unwatchable': '/unwatchable-tier.png'
+  'The Pantheon': '/images/pantheon-tier.png',
+  'Cheers Survivor': '/images/cheers-tier.png',
+  'Next Level Survivor': '/images/next-level-tier.png',
+  'Hitting on All Cylinders': '/images/all-cylinders-tier.png',
+  'The Good, the Bad, and the Ugly': '/images/good-bad-ugly-tier.png',
+  'Impossible to Rank': '/images/impossible-rank-tier.png',
+  'Replacement Level Survivor': '/images/replacement-tier.png',
+  'The New Era Malaise': '/images/new-era-malaise.png',
+  'The Shit Show Seasons': '/images/shit-show-tier.png',
+  'The Bleh': '/images/bleh-tier.png',
+  'Unwatchable': '/images/unwatchable-tier.png'
 };
 
 // Define fallback image path if a tier image is not found
-export const fallbackTierImage = '/pantheon-tier.png';
+export const fallbackTierImage = '/images/pantheon-tier.png';


### PR DESCRIPTION
## Summary
- load tier images from `/images` folder so they display in the app

## Testing
- `npm test --silent --no-warnings` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f80469d30832d89297720d5392595